### PR TITLE
IE10+ fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 
 FROM node:9
 
-COPY . /app
 WORKDIR /app
 
 ENV NODE_ENV      "production"
@@ -26,6 +25,8 @@ COPY package.json      /tmp/package.json
 COPY package-lock.json /tmp/package-lock.json
 RUN cd /tmp && npm install --production
 RUN mv /tmp/node_modules /app/node_modules
+
+COPY . .
 
 # You must use -p 9009:80 when running the image
 EXPOSE 80 

--- a/static/ehr.html
+++ b/static/ehr.html
@@ -28,7 +28,9 @@
             body {
                 margin: 0;
                 padding: 0;
+                display: -ms-flexbox;
                 display: flex;
+                -ms-flex-direction: column;
                 flex-direction: column;
                 height: 100%;
                 color: #000;
@@ -41,7 +43,9 @@
             }
             iframe {
                 border: 1px solid black;
+                display: -ms-flexbox;
                 display: flex;
+                -ms-flex: 1 1 100px;
                 flex: 1 1 100px;
                 margin: -1px 1px 1px 1px;
                 box-sizing: border-box;
@@ -50,23 +54,29 @@
                 height: 100%;
             }
             .status-bar {
+                display: -ms-flexbox;
                 display: flex;
                 background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.1));
                 box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.4) inset, 0 9px 5px -5px rgba(0, 0, 0, 0.15) inset, 0 -14px 10px -10px rgba(0, 0, 0, 0.05) inset;
                 color: #444;
                 white-space: nowrap;
+                -ms-flex-wrap: none;
                 flex-wrap: nowrap;
                 text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
             }
             
             .flex-row {
-                display       : flex;
-                flex-direction: row;
-                flex          : 1 1 0px;
-                width         : 100%;
-                max-width     : 100%;
+                display           : -ms-flexbox;
+                display           : flex;
+                -ms-flex-direction: row;
+                flex-direction    : row;
+                -ms-flex          : 1 1 0px;
+                flex              : 1 1 0px;
+                width             : 100%;
+                max-width         : 100%;
             }
             .header {
+                display    : -ms-flexbox;
                 display    : flex;
                 box-shadow : 0 0.5px 0 0 rgba(0, 0, 0, 0.3) inset, 0 1px 0px 0 #FFF inset, 0 -1px 0 0 rgba(0, 0, 0, 0.3) inset, 0 -16px 10px -10px rgba(0, 0, 0, 0.05) inset;
                 color      : #444;
@@ -74,16 +84,21 @@
                 font-size  : 120%;
             }
             .header > .flex-row {
+                -ms-flex-wrap: none;
                 flex-wrap: nowrap;
                 white-space: nowrap;
                 line-height: 40px;
             }
+
             .sidebar {
                 background: linear-gradient(rgb(225, 222, 207), rgb(182, 180, 162));
+                display: -ms-flexbox;
                 display: flex;
+                -ms-flex: 0 1 auto;
                 flex-grow: 0;
                 padding: 1em;
                 box-sizing: border-box;
+                -ms-flex-align: center;
                 align-items: center;
                 color: rgba(189, 187, 170, 0.5);
                 text-shadow: 0px 0px 0px rgba(0, 0, 0, 0.6), -1px 0px 0px rgba(255, 255, 255, 0.5);
@@ -96,7 +111,8 @@
                 margin: 0px 0px 0px -61px;
             }
             .header .patient {
-                flex: 1;
+                -ms-flex: 1 1 0px;
+                flex: 1 1 0px;
                 opacity: 0;
                 transition: opacity 0.4s;
                 margin-right: 1em;
@@ -137,6 +153,7 @@
 
             /* status-bar contents ------------------------------------------ */
             .status-bar > .flex-row {
+                -ms-flex-pack: justify;
                 justify-content: space-between;
             }
             .status-bar > .flex-row > div {
@@ -146,6 +163,7 @@
                 border-right: 1px solid rgba(0, 0, 0, 0.2);
                 border-left: 1px solid rgba(255, 255, 255, 0.5);
                 line-height: 1.2;
+                -ms-flex: 1 1 auto;
                 flex-grow: 1;
             }
             .status-bar > .flex-row > div:last-child {

--- a/static/index.html
+++ b/static/index.html
@@ -896,7 +896,8 @@
 
                     if (appLaunchUrl) {
                         var proto  = appLaunchUrl.match(/^https?/);
-                        var origin = location.origin.replace(/^https?/, proto);
+                        var origin = location.protocol.replace(/^https?/, proto) + "//" +
+                            location.host;
                         ehrLaunchUrl       = origin + ehrLaunchUrl;
                         sampleEhrLaunchUrl = origin + sampleEhrLaunchUrl;
                     }

--- a/static/sample-app/style.css
+++ b/static/sample-app/style.css
@@ -6,8 +6,11 @@ html {
 }
 
 body {
+    display    : -ms-flexbox;
     display    : flex;
+    -ms-flex-flow  : column;
     flex-flow  : column;
+    -ms-flex   : 1 1 0px;
     flex       : 1 1 0px;
     height     : 100%;
     font-family: sans-serif;
@@ -50,11 +53,16 @@ img {
 }
 
 .row {
-    flex-flow  : row;
-    display    : flex;
-    flex-wrap  : wrap;
-    align-items: stretch;
-    flex       : 1 1 0px;
+    -ms-flex-flow : row;
+    flex-flow     : row;
+    display       : -ms-flexbox;
+    display       : flex;
+    -ms-flex-wrap : wrap;
+    flex-wrap     : wrap;
+    -ms-flex-align: stretch;
+    align-items   : stretch;
+    -ms-flex      : 1 1 0px;
+    flex          : 1 1 0px;
 }
 
 .content {
@@ -66,9 +74,13 @@ img {
 }
 
 .panel {
+    /* display      : -ms-flexbox; */
     /* display      : flex; */
     display      : none;
+
+    -ms-flex-flow: column;
     flex-flow    : column;
+    -ms-flexbox  : 1 1 440px;
     flex         : 1 1 440px;
     /* max-height   : 300px; */
     margin       : 5px 15px 15px;
@@ -81,16 +93,17 @@ img {
 }
 
 .panel h4 {
-    margin     : 0 0 0 1ex;
-    padding    : 0 4px;
-    background : #FFF;
-    font-size  : 16px;
-    align-self : flex-start;
-    color      : #328c88;
-    position   : relative;
-    z-index    : 2;
-    line-height: 20px;
-    display    : inline-block;
+    margin             : 0 0 0 1ex;
+    padding            : 0 4px;
+    background         : #FFF;
+    font-size          : 16px;
+    -ms-flex-item-align: start;
+    align-self         : flex-start;
+    color              : #328c88;
+    position           : relative;
+    z-index            : 2;
+    line-height        : 20px;
+    display            : inline-block;
 }
 
 pre {
@@ -101,6 +114,7 @@ pre {
     background   : #FFF linear-gradient(#FFF, #F6F6F6);
     border-radius: 3px;
     padding      : 14px 10px 10px;
+    -ms-flexbox  : 1 1 200px;
     flex         : 1 1 200px;
     color        : #333;
     margin       : -9px 2px 2px;
@@ -115,12 +129,14 @@ pre.wrap {
 }
 
 .auth-errors {
+    -ms-flexbox: 0 1 0px;
     flex: 0 1 0px;
 }
 
 .auth-errors > div {
     padding      : 1ex;
-    flex         : 1;
+    -ms-flexbox  : 1 1 0px;
+    flex         : 1 1 0px;
     max-width    : 100%;
     border-radius: 4px;
     border       : 1px solid #dcb4b4;


### PR DESCRIPTION
This modifies the launcher to have support for IE10 and up.

In addition to all the missing `-ms-` prefixed styles for IE10 flexbox, the SMART App Launcher has a single usage of `window.location.origin` that can be replaced by using `location.protocol` and `location.host`. This previously broke the "Launch App!" button in both IE10 and IE11.

~~`monaco-editor` was also downgraded from v0.10 to v0.6 (the last version with official IE10 support)~~. I don't think this should impact anything since it appears the library is only used for syntax highlighting. Let me know if this is incorrect.