### PR TITLE
Reflect a received nonce from the authentication request in the id_token

### DIFF
--- a/src/AuthorizeHandler.js
+++ b/src/AuthorizeHandler.js
@@ -18,6 +18,7 @@ class AuthorizeHandler extends SMARTHandler {
         super(req, res);
         this.sim = this.getRequestedSIM();
         this.scope = new ScopeSet(decodeURIComponent(req.query.scope));
+        this.nonce = req.query.nonce ? decodeURIComponent(req.query.nonce) : undefined;
     }
 
     /**
@@ -210,6 +211,12 @@ class AuthorizeHandler extends SMARTHandler {
                     code.user = `Practitioner/${sim.provider}`;
                 }
             }
+        }
+
+        // Add nonce, if provided, so it can be reflected back in the subsequent
+        // token request.
+        if (this.nonce) {
+            code.nonce = this.nonce;
         }
 
         return jwt.sign(code, config.jwtSecret, { expiresIn: "5m" });

--- a/src/TokenHandler.js
+++ b/src/TokenHandler.js
@@ -211,13 +211,21 @@ class TokenHandler extends SMARTHandler {
     createIdToken(clientDetailsToken) {
         let secure = this.request.secure || this.request.headers["x-forwarded-proto"] == "https";
         let iss    = config.baseUrl.replace(/^https?/, secure ? "https" : "http");
-        return jwt.sign({
+        let payload = {
             profile : clientDetailsToken.user,
             fhirUser: clientDetailsToken.user,
             aud     : this.request.body.client_id,
             sub     : crypto.createHash('sha256').update(clientDetailsToken.user).digest('hex'),
             iss
-        }, PRIVATE_KEY, {
+        };
+        // Reflect back the nonce if it was provided in the original Authentication
+        // Request.
+        let { nonce } = clientDetailsToken;
+        if (nonce) {
+            payload.nonce = nonce;
+        }
+
+        return jwt.sign(payload, PRIVATE_KEY, {
             algorithm: "RS256",
             expiresIn: `${(clientDetailsToken.accessTokensExpireIn || 60)} minutes`
         });


### PR DESCRIPTION
Adds a received nonce to the payload of the JWT used for the code. If
present in the token request it's then echo'ed back in the id_token.

Resolves #18