### PR TITLE
Set aud claim in id_token to client_id from the original auth request

### DIFF
--- a/src/TokenHandler.js
+++ b/src/TokenHandler.js
@@ -214,7 +214,7 @@ class TokenHandler extends SMARTHandler {
         return jwt.sign({
             profile : clientDetailsToken.user,
             fhirUser: clientDetailsToken.user,
-            aud     : this.request.body.client_id,
+            aud     : clientDetailsToken.client_id,
             sub     : crypto.createHash('sha256').update(clientDetailsToken.user).digest('hex'),
             iss
         }, PRIVATE_KEY, {


### PR DESCRIPTION
The client_id is received in the Basic Auth header for the token request
so isn't part of the request body.

Resolves #20