### PR TITLE
including etag and location headers through proxy

### DIFF
--- a/src/simple-proxy.js
+++ b/src/simple-proxy.js
@@ -127,8 +127,12 @@ module.exports = (req, res) => {
         })
         .on('response', response => {
             let contentType = response.headers['content-type'];
+            let etag = response.headers['etag']
+            let location = response.headers['location']
             res.status(response.statusCode);
             contentType && res.type(contentType);
+            etag && res.set('ETag', etag)
+            location && res.set('Location', location)
             if (logTime) {
                 console.log(
                     ("Simple Proxy: ".bold + Url.format(fhirRequestOptions.url) + " -> ").cyan +


### PR DESCRIPTION
Hello, 

I noticed that the proxy was not allowing the ETag and Location headers to flow through from the HAPI FHIR Server. I have an app that allows users to provide updates to the Condition resource and need the versioning headers to come through in order for it to work. 

I added code to parse out the Location and ETag headers and include them on the response from the proxy. 

Thanks,
James

Before:
<img width="730" alt="beforeChanges" src="https://user-images.githubusercontent.com/700919/62383284-0d160b80-b515-11e9-8ede-4d2787ea57bf.png">

After:
<img width="562" alt="afterChanges" src="https://user-images.githubusercontent.com/700919/62383332-20c17200-b515-11e9-859a-0feb5c1c4a06.png">
