### PR TITLE
Added a Few More Required Elements to the OIDC Discovery Metadata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const config         = require("./config");
 const generator      = require("./generator");
 const lib            = require("./lib");
 const launcher       = require("./launcher");
+const wellKnownOIDC  = require("./wellKnownOIDCConfiguration");
 const wellKnownSmart = require("./wellKnownSmartConfiguration");
 
 
@@ -83,10 +84,8 @@ if (IP_BLACK_LIST.length) {
 //reject xml
 app.use(handleXmlRequest);
 
-//provide oidc keys when requested
-app.get("/.well-known/openid-configuration/", (req, res) => {
-    res.json({"jwks_uri": `${config.baseUrl}/keys`})
-});
+// Well-known OpenID Connect (OIDC) Configuration
+app.get("/.well-known/openid-configuration/", wellKnownOIDC);
 
 app.get("/keys", (req, res) => {
     let key = {}

--- a/src/wellKnownOIDCConfiguration.js
+++ b/src/wellKnownOIDCConfiguration.js
@@ -1,0 +1,51 @@
+const config = require("./config");
+
+
+/**
+ * Given a request object, returns its base URL
+ */
+function getRequestBaseURL(req) {
+    const host = req.headers["x-forwarded-host"] || req.headers.host;
+    const protocol = req.headers["x-forwarded-proto"] || req.protocol || "http";
+    return protocol + "://" + host;
+}
+
+module.exports = (req, res) => {
+    const prefix = `${getRequestBaseURL(req)}${
+        (req.originalUrl || req.originalUrl)
+        .replace(/\/\.well-known\/openid-configuration$/, "")
+        }${config.authBaseUrl}`;
+
+    const json = {
+
+        // REQUIRED. URL using the https scheme with no query or fragment component that the OP asserts as 
+        // its Issuer Identifier. If Issuer discovery is supported (see Section 2), this value MUST be identical 
+        // to the issuer value returned by WebFinger. This also MUST be identical to the iss Claim value in 
+        // ID Tokens issued from this Issuer. 
+        issuer: `${config.baseUrl}`,
+
+        // REQUIRED. URL of the OPs JSON Web Key Set [JWK] document. This contains the signing key(s) the RP uses 
+        // to validate signatures from the OP. The JWK Set MAY also contain the Server's encryption key(s), 
+        // which are used by RPs to encrypt requests to the Server. When both signing and encryption keys are made 
+        // available, a use (Key Use) parameter value is REQUIRED for all keys in the referenced JWK Set to indicate 
+        // each keys intended usage. Although some algorithms allow the same key to be used for both signatures and 
+        // encryption, doing so is NOT RECOMMENDED, as it is less secure. The JWK x5c parameter MAY be used to provide 
+        // X.509 representations of keys provided. When used, the bare key values MUST still be present and MUST match 
+        // those in the certificate.  
+        jwks_uri: `${config.baseUrl}/keys`,
+
+        // REQUIRED, URL to the OAuth2 authorization endpoint.
+        authorization_endpoint: `${prefix}/authorize`,
+
+        // REQUIRED, URL to the OAuth2 token endpoint.
+        token_endpoint: `${prefix}/token`,
+
+        // REQUIRED. JSON array containing a list of the Subject Identifier types that this OP supports. Valid types include pairwise and public. 
+        "subject_types_supported": [
+            "public"
+        ]
+
+    };
+
+    res.json(json);
+};


### PR DESCRIPTION
Following the pattern established for the existing SMART configuration, I added a more complete implementation of the OIDC configuration that now allows these details to be properly used during a standard OIDC id-token validation.