### PR TITLE
Introspection endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Launcher for SMART apps",
   "main": "./src/index.js",
   "scripts": {
-    "watch": "DOTENV_CONFIG_PATH=env/development.env node -r dotenv/config ./node_modules/.bin/nodemon ./src/index.js",
+    "watch": "DOTENV_CONFIG_PATH=env/development.env node -r dotenv/config ./node_modules/.bin/nodemon --inspect ./src/index.js",
     "start": "node ./src/index.js",
     "test": "DOTENV_CONFIG_PATH=env/test.env node -r dotenv/config ./node_modules/.bin/mocha test/*.js",
     "test:cover": "DOTENV_CONFIG_PATH=env/test.env node -r dotenv/config ./node_modules/.bin/nyc --reporter=lcov --reporter=text mocha test/*.js",

--- a/src/index.js
+++ b/src/index.js
@@ -130,15 +130,15 @@ app.get(buildRoutePermutations("/authorize"), (req, res) => {
     res.sendFile("authorize.html", {root: './static'});
 });
 
-// auth request
-app.use(buildRoutePermutations(config.authBaseUrl), smartAuth)
-
 // introspect
 app.post(
-    buildRoutePermutations("/introspect"),
+    buildRoutePermutations(`${config.authBaseUrl}/introspect`),
     express.urlencoded({ limit: '64kb', extended: false }),
     introspectionHandler
 );
+
+// auth request
+app.use(buildRoutePermutations(config.authBaseUrl), smartAuth)
 
 // Provide launch_id if the CDS Sandbox asks for it
 app.post(buildRoutePermutations("/fhir/_services/smart/launch"), bodyParser.json(), (req, res) => {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const lib            = require("./lib");
 const launcher       = require("./launcher");
 const wellKnownOIDC  = require("./wellKnownOIDCConfiguration");
 const wellKnownSmart = require("./wellKnownSmartConfiguration");
-
+const { introspectionHandler } = require("./introspect")
 
 const handleParseError = function(err, req, res, next) {
     if (err instanceof SyntaxError && err.status === 400) {
@@ -132,6 +132,13 @@ app.get(buildRoutePermutations("/authorize"), (req, res) => {
 
 // auth request
 app.use(buildRoutePermutations(config.authBaseUrl), smartAuth)
+
+// introspect
+app.post(
+    buildRoutePermutations("/introspect"),
+    express.urlencoded({ limit: '64kb', extended: false }),
+    introspectionHandler
+);
 
 // Provide launch_id if the CDS Sandbox asks for it
 app.post(buildRoutePermutations("/fhir/_services/smart/launch"), bodyParser.json(), (req, res) => {

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -107,6 +107,14 @@ function introspectionHandler(req, res) {
             jti: token.jti,
         }
     } catch {
+        // If the introspection call is properly authorized but the token is not
+        // active, does not exist on this server, or the protected resource is
+        // not allowed to introspect this particular token, then the
+        // authorization server MUST return an introspection response with the
+        // "active" field set to "false".  Note that to avoid disclosing too
+        // much of the authorization server's state to a third party, the
+        // authorization server SHOULD NOT include any additional information
+        // about an inactive token, including why the token is inactive.
         response = { active: false }
     }
 

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -30,6 +30,11 @@ function introspectionHandler(req, res) {
     // that the JWT is valid, which an un-authorized user could determine by using it as the authorization token.
 
     // Perform introspection
+
+    if (!req.body.token) {
+        return res.status(400).send("No token provided");
+    }
+
     let response;
 
     try {

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -15,17 +15,10 @@ function introspectionHandler(req, res) {
     }
 
     try {
-        let token = null;
-        
         jwt.verify(
             req.headers.authorization.split(" ")[1],
             config.jwtSecret
         );
-
-        // Simulated errors
-        if (token?.sim_error) {
-            return res.status(401).send(token.sim_error);
-        }
     } catch (e) {
         return res.status(401).send(
             `${e.name || "Error"}: ${e.message || "Invalid token"}`

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -10,7 +10,7 @@ function introspectionHandler(req, res) {
 
     // Validate authorization token ----------------------------------------------------------
     if(!req.headers.authorization) {
-        res.status(401).send("Invalid token");
+        res.status(401).send("Authorization is required");
         return
     }
 

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -1,0 +1,98 @@
+const { read } = require("fs");
+const jwt        = require("jsonwebtoken");
+const config     = require("./config");
+
+// Spec: https://tools.ietf.org/html/rfc7662
+function introspectionHandler(req, res) {
+
+    /* "To prevent token scanning attacks, the endpoint MUST also require
+    some form of authorization to access this endpoint" */
+
+    // Validate authorization token ----------------------------------------------------------
+    if(!req.headers.authorization) {
+        res.status(401).send("Invalid token");
+        return
+    }
+
+    try {
+        let token = null;
+        
+        jwt.verify(
+            req.headers.authorization.split(" ")[1],
+            config.jwtSecret
+        );
+
+        // Simulated errors
+        if (token?.sim_error) {
+            return res.status(401).send(token.sim_error);
+        }
+    } catch (e) {
+        return res.status(401).send(
+            `${e.name || "Error"}: ${e.message || "Invalid token"}`
+        );
+    }
+
+    // In theory, there could be some further authorization step, such as in a case where a 3rd party server had
+    // many tokens under its management. However, the only real work the server is doing here is to disclose
+    // that the JWT is valid, which an un-authorized user could determine by using it as the authorization token.
+
+    // Perform introspection
+    let response;
+
+    try {
+        const token = jwt.decode(req.body.token, config.jwtSecret)
+    
+        response = {
+    
+            /*  REQUIRED.  Boolean indicator of whether or not the presented token
+            is currently active.  The specifics of a token's "active" state
+            will vary depending on the implementation of the authorization
+            server and the information it keeps about its tokens, but a "true"
+            value return for the "active" property will generally indicate
+            that a given token has been issued by this authorization server,
+            has not been revoked by the resource owner, and is within its
+            given time window of validity (e.g., after its issuance time and
+            before its expiration time).  See Section 4 for information on
+            implementation of such checks. */
+            active: true,
+    
+            /* OPTIONAL.  A JSON string containing a space-separated list of
+            scopes associated with this token, in the format described in
+            Section 3.3 of OAuth 2.0 [RFC6749]. */
+            scope: token.scope,
+    
+            /* OPTIONAL.  Client identifier for the OAuth 2.0 client that
+            requested this token. */
+            client_id: token.client_id,
+    
+            /* OPTIONAL.  Human-readable identifier for the resource owner who
+            authorized this token. */
+            // username: undefined, 
+    
+            /*   OPTIONAL.  Type of the token as defined in Section 5.1 of OAuth
+            2.0 [RFC6749]. */
+            token_type: token.token_type,
+    
+            /* OPTIONAL.  Integer timestamp, measured in the number of seconds
+            since January 1 1970 UTC, indicating when this token will expire,
+            as defined in JWT [RFC7519]. */
+            exp: token.exp,
+    
+            /* OPTIONAL.  Integer timestamp, measured in the number of seconds
+            since January 1 1970 UTC, indicating when this token was
+            originally issued, as defined in JWT [RFC7519]. */
+            iat: token.iat,
+    
+            /* OPTIONAL.  Integer timestamp, measured in the number of seconds
+            since January 1 1970 UTC, indicating when this token is not to be
+            used before, as defined in JWT [RFC7519]. */
+            // nbf: undefined
+        }
+    } catch {
+        response = { active: false }
+    }
+
+    res.json(response)
+}
+
+module.exports = { introspectionHandler }

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -67,7 +67,7 @@ function introspectionHandler(req, res) {
     
             /* OPTIONAL.  Human-readable identifier for the resource owner who
             authorized this token. */
-            // username: undefined, 
+            username: token.username, 
     
             /*   OPTIONAL.  Type of the token as defined in Section 5.1 of OAuth
             2.0 [RFC6749]. */
@@ -86,7 +86,25 @@ function introspectionHandler(req, res) {
             /* OPTIONAL.  Integer timestamp, measured in the number of seconds
             since January 1 1970 UTC, indicating when this token is not to be
             used before, as defined in JWT [RFC7519]. */
-            // nbf: undefined
+            nbf: token.nbf,
+
+            // OPTIONAL.  Subject of the token, as defined in JWT [RFC7519].
+            // Usually a machine-readable identifier of the resource owner who
+            // authorized this token.
+            sub: token.sub,
+      
+            // OPTIONAL.  Service-specific string identifier or list of string
+            // identifiers representing the intended audience for this token, as
+            // defined in JWT [RFC7519].
+            aud: token.aud,
+            
+            // OPTIONAL.  String representing the issuer of this token, as
+            // defined in JWT [RFC7519].
+            iss: token.iss,
+      
+            // OPTIONAL.  String identifier for the token, as defined in JWT
+            // [RFC7519].
+            jti: token.jti,
         }
     } catch {
         response = { active: false }

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -40,7 +40,7 @@ function introspectionHandler(req, res) {
     let response;
 
     try {
-        const token = jwt.decode(req.body.token, config.jwtSecret)
+        const token = jwt.verify(req.body.token, config.jwtSecret)
     
         response = {
     

--- a/src/lib.js
+++ b/src/lib.js
@@ -212,6 +212,10 @@ function augmentConformance(bodyText, authBaseUrl) {
             {
                 "url": "token",
                 "valueUri": buildUrlPath(authBaseUrl, "/token")
+            },
+            {
+                "url": "introspect",
+                "valueUri": buildUrlPath("/introspect")
             }
         ]
     }];

--- a/src/lib.js
+++ b/src/lib.js
@@ -215,7 +215,7 @@ function augmentConformance(bodyText, authBaseUrl) {
             },
             {
                 "url": "introspect",
-                "valueUri": buildUrlPath("/introspect")
+                "valueUri": buildUrlPath(authBaseUrl, "/introspect")
             }
         ]
     }];

--- a/src/wellKnownOIDCConfiguration.js
+++ b/src/wellKnownOIDCConfiguration.js
@@ -32,6 +32,9 @@ module.exports = (req, res) => {
         // REQUIRED, URL to the OAuth2 token endpoint.
         token_endpoint: `${prefix}/token`,
 
+        // OPTIONAL, URL of the authorization server's introspection endpoint.	
+        introspection_endpoint: `${prefix}/introspect`,
+
         // REQUIRED. JSON array containing a list of the Subject Identifier types that this OP supports. Valid types include pairwise and public. 
         "subject_types_supported": [
             "public"

--- a/src/wellKnownSmartConfiguration.js
+++ b/src/wellKnownSmartConfiguration.js
@@ -26,7 +26,7 @@ module.exports = (req, res) => {
 
         // RECOMMENDED, URL to a server’s introspection endpoint that can be
         // used to validate a token.
-        "introspection_endpoint": undefined,
+        "introspection_endpoint": `${prefix}/introspect`,
 
         // RECOMMENDED, URL to a server’s revoke endpoint that can be used to
         // revoke a token.

--- a/test/api.js
+++ b/test/api.js
@@ -926,7 +926,7 @@ describe('Auth', function() {
                     }
                 }).then(token => {
                     request(app)
-                        .post(`${path}introspect`)
+                        .post(`${path}auth/introspect`)
                         .set('Authorization', `Bearer ${token.access_token}`)
                         .set('Accept', 'application/json')
                         .set('Content-Type', 'application/x-www-form-urlencoded')

--- a/test/api.js
+++ b/test/api.js
@@ -909,6 +909,38 @@ describe('Auth', function() {
             });
         });
     });
+
+    describe('Introspection', () => {
+
+        buildRoutePermutations().forEach(path => {
+            it(`can introspect ${path}`, (done) => {
+                authorize({
+                    scope  : "offline_access",
+                    baseUrl: config.baseUrl + path,
+                    launch : {
+                        launch_pt : 1,
+                        skip_login: 1,
+                        skip_auth : 1,
+                        patient   : "abc",
+                        encounter : "bcd",
+                    }
+                }).then(token => {
+                    request(app)
+                        .post(`${path}introspect`)
+                        .set('Authorization', `Bearer ${token.access_token}`)
+                        .set('Accept', 'application/json')
+                        .set('Content-Type', 'application/x-www-form-urlencoded')
+                        .send({ token: token.access_token })
+                        .expect(200)
+                        .expect(res => {
+                            if(res.body?.active !== true) throw new Error("Token is not active." + JSON.stringify(res.body))
+                        })
+                        .end(done)
+
+                }).catch(done)
+            })
+        })
+    })
 });
 
 describe('Generator', () => {

--- a/test/api.js
+++ b/test/api.js
@@ -909,39 +909,104 @@ describe('Auth', function() {
             });
         });
     });
+});
 
-    describe('Introspection', () => {
+describe('Introspection', () => {
+    buildRoutePermutations().forEach(path => {
+        it(`gets correct FHIR conformance for ${path}`, () => {
+            return request(app)
+            .get(`${path}fhir/metadata`)
+            .expect(200)
+            .then(response => {
+                const oauthUris = response.body.rest[0].security.extension.find(e => /StructureDefinition\/oauth-uris$/.test(e.url));
+                expect(oauthUris);
+                const introspection = oauthUris.extension.find(e => e.url === "introspect");
+                expect(introspection);
+                expect(new URL(introspection.valueUri).pathname).equal(`${path}auth/introspect`);
+            })
+        })
 
-        buildRoutePermutations().forEach(path => {
-            it(`can introspect ${path}`, (done) => {
-                authorize({
-                    scope  : "offline_access",
-                    baseUrl: config.baseUrl + path,
-                    launch : {
-                        launch_pt : 1,
-                        skip_login: 1,
-                        skip_auth : 1,
-                        patient   : "abc",
-                        encounter : "bcd",
-                    }
-                }).then(token => {
-                    request(app)
-                        .post(`${path}auth/introspect`)
-                        .set('Authorization', `Bearer ${token.access_token}`)
-                        .set('Accept', 'application/json')
-                        .set('Content-Type', 'application/x-www-form-urlencoded')
-                        .send({ token: token.access_token })
-                        .expect(200)
-                        .expect(res => {
-                            if(res.body?.active !== true) throw new Error("Token is not active." + JSON.stringify(res.body))
-                        })
-                        .end(done)
+        it(`can introspect an access token ${path}`, (done) => {
+            authorize({
+                scope  : "offline_access",
+                baseUrl: config.baseUrl + path,
+                launch : {
+                    launch_pt : 1,
+                    skip_login: 1,
+                    skip_auth : 1,
+                    patient   : "abc",
+                    encounter : "bcd",
+                }
+            }).then(token => {
+                request(app)
+                    .post(`${path}auth/introspect`)
+                    .set('Authorization', `Bearer ${token.access_token}`)
+                    .set('Accept', 'application/json')
+                    .set('Content-Type', 'application/x-www-form-urlencoded')
+                    .send({ token: token.access_token })
+                    .expect(200)
+                    .expect(res => {
+                        if(res.body?.active !== true) throw new Error("Token is not active.");
+                    })
+                    .end(done);
 
-                }).catch(done)
+            }).catch(done)
+        })
+
+        it(`can introspect a refresh token ${path}`, (done) => {
+            authorize({
+                scope  : "offline_access",
+                baseUrl: config.baseUrl + path,
+                launch : {
+                    launch_pt : 1,
+                    skip_login: 1,
+                    skip_auth : 1,
+                    patient   : "abc",
+                    encounter : "bcd",
+                }
+            }).then(token => {
+                request(app)
+                    .post(`${path}auth/introspect`)
+                    .set('Authorization', `Bearer ${token.access_token}`)
+                    .set('Accept', 'application/json')
+                    .set('Content-Type', 'application/x-www-form-urlencoded')
+                    .send({ token: token.refresh_token })
+                    .expect(200)
+                    .expect(res => {
+                        if(res.body?.active !== true) throw new Error("Token is not active.");
+                    })
+                    .end(done);
+
+            }).catch(done)
+        })
+
+        it(`gets active: false for authorized request with invalid token at ${path}`, (done) => {
+            const introspectionToken = 'invalid';
+            
+            authorize({
+                scope  : "offline_access",
+                baseUrl: config.baseUrl + path,
+                launch : {
+                    launch_pt : 1,
+                    skip_login: 1,
+                    skip_auth : 1,
+                    patient   : "abc",
+                    encounter : "bcd",
+                }
+            }).then(auth => {
+                request(app)
+                    .post(`${path}auth/introspect`)
+                    .set('Authorization', `Bearer ${auth.access_token}`)
+                    .set('Accept', 'application/json')
+                    .set('Content-Type', 'application/x-www-form-urlencoded')
+                    .send({ token: introspectionToken })
+                    .expect(200)
+                    .expect({ active: false })
+                    .end(done);
             })
         })
     })
-});
+})
 
 describe('Generator', () => {
     describe('RSA Generator', function() {


### PR DESCRIPTION
Fixes #29 

- [x] Add introspection to conformance statement
- [x] Add introspection to OIDC well known
- [x] Add introspection to SMART well known
- [x] Add introspection endpoint
- [x] Can submit a refresh token
- [x] Tests

Notes:
* I am not testing the .well-knowns explicitly. I wasn't clear from our conversation how important those were but certainly could do so.
* What version of node is this deployed on?
* I don't like that I've copy/pasted both the auth code for the endpoint and the validation logic for the token in the payload, but didn't want to start refactoring other places where similar code is used in this PR. Related, per our discussion, jsonwebtoken#verify does check [token expiration by default](https://github.com/auth0/node-jsonwebtoken/blob/88cb9df18a1d2a7b24f8cfeaa6f5f5b87d2c027f/verify.js#L147). I would like to make this explicit in the options for future readers, but thought doing so might appear to be confusing if I didn't also do so elsewhere.
* ~I am not explicitly testing an expired token. I don't think it is worth the code complexity to pull the token signing out into a utility and re-using it in the test suite and dealing with timing, but it wouldn't be unreasonable.~ Updated
