### PR TITLE
Use alpine baseimage for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # then the image should be started using the same port like:
 #    docker run -t -p 9009:80 -d smartonfhir/smart-launcher:latest
 
-FROM node:14
+FROM node:14-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
The difference is notable:
```
smartonfhir/smart-launcher with node:14-alpine 229MB
smartonfhir/smart-launcher with node:14             1.07GB
```